### PR TITLE
chore: :sparkles: Add .gitattributes to enforce LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Set default behavior to automatically normalize line endings for text files
+# (Mainly for windows users)
+
+* text eol=lf
+
+*.png binary
+*.jpg binary


### PR DESCRIPTION
windowsでcloneした際、gitの設定が`core.autocrlf = true`になっていると色々面倒なことになるので。