### PR TITLE
refactor: pythonファイルから不要な権限を削除

### DIFF
--- a/src/sinsei_umiusi_core/low_power_health_check/low_power_health_check.py
+++ b/src/sinsei_umiusi_core/low_power_health_check/low_power_health_check.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import sys
 
 import rclpy


### PR DESCRIPTION
CMakeで権限を自動付与できるようになったため